### PR TITLE
#32 RouteList save Endpoint - Not working with relations

### DIFF
--- a/src/main/java/de/orfap/fap/backend/controller/RouteController.java
+++ b/src/main/java/de/orfap/fap/backend/controller/RouteController.java
@@ -44,6 +44,16 @@ public class RouteController {
   RouteRepository routeRepository;
 
   /**
+   * Saves a list of routes at once.
+   * @param routes list of routes to save.
+   * @return saved routes.
+   */
+  @RequestMapping(value = "saveAll", method = RequestMethod.POST)
+  public Iterable<Route> saveAll(@RequestBody Iterable<Route> routes){
+    return routeRepository.save(routes);
+  }
+
+  /**
    * Find routes by a given year.
    * @param year to filter routes by
    * @return routes of given year


### PR DESCRIPTION
List Save implementiert. Aber aufgrund einer Spring bzw. Jackson Limitierung müsst ihr für Source/Destination/Market die richtigen Objekte mitschicken und nicht nur die Links. D.h. ein Request für 2 Routen schaut dann so aus:

``` json
[
    {
        "date": "2015-01-01",
        "source": {
            "name": "Bla",
            "id": "xxx"
        },
        "destination": {
            "name": "Bla",
            "id": "xxx"
        },
        "airline": {
            "name": "kla",
            "id": "yyy"
        }
    },
    {
        "date": "2015-01-02",
        "source": {
            "name": "Bla",
            "id": "xxx"
        },
        "destination": {
            "name": "Bla",
            "id": "xxx"
        },
        "airline": {
            "name": "kla",
            "id": "yyy"
        }
    }
]
```

Der Endpunkt ist: /routes/saveAll
Methode: Post
Body: Liste von Routen

@o4ier 
@Arne2 
